### PR TITLE
make the help text sound clearer

### DIFF
--- a/sopel_modules/quotes/quotes.py
+++ b/sopel_modules/quotes/quotes.py
@@ -2,7 +2,7 @@
 # vim: set noai ts=4 sw=4:
 
 """
-Sopel Quotes is a module for handling user added IRC quotes
+Sopel Quotes -  A module for handling user added IRC quotes
 """
 from random import seed
 from sopel.config.types import StaticSection, ValidatedAttribute


### PR DESCRIPTION
This appears on sopel configure --plugins and makes better sense in this format.

Should we also switch this to plugin here?